### PR TITLE
fix sdktools WeaponEquip offsets

### DIFF
--- a/gamedata/sdktools.games/custom/game.open_fortress.txt
+++ b/gamedata/sdktools.games/custom/game.open_fortress.txt
@@ -91,9 +91,9 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"263"
-				"linux"		"264"
-				"mac"		"264"
+				"windows"	"278"
+				"linux"		"279"
+				"mac"		"279"
 			}
 			"Activate"
 			{


### PR DESCRIPTION
While working on a plugin for revision 18 I discovered that these offsets were incorrect. New offsets were found via https://asherkin.github.io/vtable/ for `CTFWeaponBase::Weapon_Equip`

![image](https://github.com/brysondev/Open-Fortress-Tools/assets/20617130/13ee27b5-1104-4572-ac1a-8809d101abde)
